### PR TITLE
zipCodeQuery Controller finished

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
@@ -1,9 +1,39 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.spring.backenddemo.services.CollegeSubredditQueryService;
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
 @RestController
+@Api(description="Zip code info service")
+@RequestMapping("/api/zipcode")
+@Log4j2
 public class ZipCodeController {
-    
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    ZipCodeQueryService zipCodeQueryService;
+
+    @ApiOperation(value="get info about zip code")
+    @GetMapping("/get")
+    public ResponseEntity<String> getZipCode(
+            @ApiParam("zip code, e.g. 93117") @RequestParam String zipCode
+    ) throws JsonProcessingException {
+        log.info("getCountryCodes: zipCode={}", zipCode);
+        String result = zipCodeQueryService.getJSON(zipCode);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -7,18 +9,33 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+import java.util.List;
+import java.util.Map;
+
 @Service
+@Log4j2
 public class ZipCodeQueryService {
 
     private final RestTemplate restTemplate;
+    public static final String ENDPOINT = "http://api.zippopotam.us/us/{zipcode}";
 
     public ZipCodeQueryService(RestTemplateBuilder restTemplateBuilder) {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
-
     public String getJSON(String zipcode) throws HttpClientErrorException {
-       return "";
+
+        log.info("zipcode={}", zipcode);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> uriVariables = Map.of("zipcode", zipcode);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeQueryControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeQueryControllerTest.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import edu.ucsb.cs156.spring.backenddemo.services.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.CollegeSubredditQueryService;
+
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+
+
+@WebMvcTest(value = ZipCodeController.class)
+public class ZipCodeQueryControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    ZipCodeQueryService mockZipCodeQueryService;
+    @MockBean
+    CountryCodeQueryService mockCountryCodeQueryService;
+
+    @Test
+    public void test_getZip() throws Exception {
+
+        String fakeJsonResult="{ \"fake\" : \"result\" }";
+        String zip = "93117";
+        when(mockZipCodeQueryService.getJSON(zip)).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/zipcode/get?zipCode=%s", zip);
+
+        MvcResult response = mockMvc
+                .perform( get(url).contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
@@ -1,0 +1,46 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.spring.backenddemo.beans.CollegeSubreddit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RestClientTest(ZipCodeQueryService.class)
+public class ZipCodeQueryServiceTests {
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private ZipCodeQueryService zipCodeQueryService;
+
+    @Test
+    public void test_getJSON() throws URISyntaxException, UnsupportedEncodingException, JsonProcessingException {
+
+        String zip = "93117";
+        String expectedURL = ZipCodeQueryService.ENDPOINT.replace("{zipcode}", zip);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = zipCodeQueryService.getJSON(zip);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/zipcode/get` that can be used to get information
about the location of a particular zipcode.  